### PR TITLE
[Design] 탭 바의 아이템이 선택되었을 때 색상 변경

### DIFF
--- a/iOSClock/Controller/TabBarController.swift
+++ b/iOSClock/Controller/TabBarController.swift
@@ -25,5 +25,7 @@ class TabBarController: UITabBarController {
         timerTab.tabBarItem = UITabBarItem(title: "타이머", image: UIImage(systemName: "timer"), selectedImage: UIImage(systemName: "timer")?.withTintColor(UIColor.orange))
         
         self.viewControllers = [worldTimeTab, alarmTab, stopWatchTab, timerTab]
+        
+        self.tabBar.tintColor = .systemOrange
     }
 }


### PR DESCRIPTION
## Motivation 🥳 (코드를 추가/변경하게 된 이유)
- 탭 바의 아이템이 선택되었을 때의 색상을 기본 색상이 아닌 시계의 색상과 비슷하게 변경하기 위함

## Key Changes 🔥 (주요 구현/변경 사항)
- 탭바의 아이템이 선택되었을 때의 색상 변경

## ToDo 📆 (남은 작업)
- 없음

## ScreenShot 📷 (참고 사진)
<img src="https://user-images.githubusercontent.com/81027256/188280274-e884ed95-377a-4b14-88a0-de41e6e0b76e.gif" width="300">

## To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)
- 한 줄짜리 간단한 코드입니다. 가볍게 리뷰해주셔도 좋습니다~
- ~~세계 시계 아이콘은 SF Symbols에서 같은 아이콘을 찾지 못해서, 최대한 비슷한 아이콘으로 대체했습니다. 혹시 같은 아이콘을 찾게 된다면 알려주세요\~~~ (같은 아이콘을 발견해서 #8 로 반영합니다)
- tintColor는 현재 `systemOrange`로 설정되어 있는데, 실제 시계앱에서는 약간 다른 색을 사용하고 있는 것 같습니다. 시계 앱과 같은 색으로 할지, 아니면 systemOrange로 그냥 갈지 코멘트로 의논해보면 좋을 것 같습니다.

## Reference 🔗
- [Swift Production - Create a UITabBar Programmatically](https://medium.com/swift-productions/create-a-uitabbar-programmatically-xcode-12-swift-5-3-740d5491631c)
## Close Issues 🔒 (닫을 Issue)
Close #4 
