### PR TITLE
[Chore] 앱 디스플레이 네임 변경

### DIFF
--- a/iOSClock.xcodeproj/project.pbxproj
+++ b/iOSClock.xcodeproj/project.pbxproj
@@ -373,6 +373,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = iOSClock/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = "시계";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
@@ -399,6 +400,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = iOSClock/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = "시계";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";


### PR DESCRIPTION
## Motivation 🥳 (코드를 추가/변경하게 된 이유)
- 디바이스에서 보여지는 이름이 프로젝트 이름으로 되어있어 변경

## Key Changes 🔥 (주요 구현/변경 사항)
- 앱 디스플레이 네임을 `시계`로 변경

## ToDo 📆 (남은 작업)
- 없음

## ScreenShot 📷 (참고 사진)
<img width="94" alt="스크린샷 2022-09-04 12 59 11" src="https://user-images.githubusercontent.com/81027256/188296687-874811a2-28ca-49c7-b6b0-100ff23c89c8.png">

## To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)
- 코드적인 변경사항이라기 보다는 간단하게 디스플레이 네임만 변경했습니다. 가볍게 리뷰해주세요~

## Reference 🔗
- 없음

## Close Issues 🔒 (닫을 Issue)
Close #9
